### PR TITLE
Improves handling of intermittently specified bit_offset 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+## [0.0.9] - 2018-11-19
+
+### Changed
+
+ - Improve handling of packet definitions with intermittently specified bit_offset (ie. some bit_offset specified, others None).
+ - Respect byte_ordering for float datatypes.
+
 ## [0.0.8] - 2018-10-11
 ### Changed
 - Removed astropy dependency. Changes return type of ccsdspy.FixedLength.load from astropy.table.Table to OrderedDict. 

--- a/ccsdspy/decode.py
+++ b/ccsdspy/decode.py
@@ -58,9 +58,9 @@ def _decode_fixed_length(file_bytes, fields):
     if all(field._bit_offset is None for field in fields):
         assert counter == packet_nbytes * 8, \
             'Field definition != packet length'.format(n=counter-packet_nbytes*8)
-    else:
-        assert counter <= packet_nbytes * 8, \
-            'Field definition larger than packet length by {} bits'.format(counter-packet_nbytes*8)
+    elif counter > packet_nytes * 8:
+        raise RuntimeError(("Packet definition larger than packet length"
+                            " by {} bits").format(counter-(packet_nbytes*8)))
         
     # Setup metadata for each field, consiting of where to look for the field in
     # the file and how to parse it.

--- a/ccsdspy/decode.py
+++ b/ccsdspy/decode.py
@@ -51,7 +51,9 @@ def _decode_fixed_length(file_bytes, fields):
             bit_offset[field._name] = field._bit_offset
             counter = field._bit_offset + field._bit_length
         else:
-            assert False, "All cases should be handled above."
+            raise RuntimeError(("Unexpected case: could not compare"
+                                " bit_offset {} with counter {} for field {}"
+                                ).format(field._bit_offset, counter, field._name))
 
     if all(field._bit_offset is None for field in fields):
         assert counter == packet_nbytes * 8, \
@@ -155,3 +157,4 @@ def _decode_fixed_length(file_bytes, fields):
         field_arrays[field._name] = arr
 
     return field_arrays
+

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ AUTHOR_EMAIL = ''
 LICENSE = 'unknown'
 URL = 'http://github.com/ddasilva/ccsdspy'
 # VERSION should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-VERSION = '0.0.8'
+VERSION = '0.0.9'
 
 setup(
     name=PACKAGENAME,


### PR DESCRIPTION
Previously, beginning of the packet was "floating" in the
sense that the bit start position depended on how many bits
total were specified. This reasonably allows the omission
of fields (so that the definition does not fill the whole
packet), but that the definition would span to the end of
the packet. Implicitly, what was omitted would be assumed
to be the header (or more).

We've run into the situation where the length of a packet
might change at some point, but the change adds more
fields to the end of the packet... while the existing
structure of the packet remains the same.

Given the described, floating behavior of ccsdspy, the
same packet definition would not work. One initial idea
was to fix the start of the packet by specifying exactly
the start of the packet... eg. first bit_offset = 0.

This caused problems when leaving the rest of the
bit_offsets unspecified because, even though the first
packet would be at the start, the remaining would
misalign due to the counter variable not taking the
fixed start into account.

This commit improves handling of intermingled packet
definitions where some fields may have bit_offset
specified and other may not (ie bit_offset = None).