### PR TITLE
Remove Python 3.3 from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"


### PR DESCRIPTION
Travis CI build failing for not finding Python 3.3... perhaps because Python 3.3 has reached EOL?

> As of 2017-09-29, Python 3.3.x reached end-of-life status.

https://www.python.org/dev/peps/pep-0398/#lifespan