### PR TITLE
Implement API for post-processing converters

### DIFF
--- a/ccsdspy/converters.py
+++ b/ccsdspy/converters.py
@@ -1,0 +1,189 @@
+"""This class hold the implementation of the converter sysytem, which applies 
+post-process to decoded packet fields. This post-processing includes applying
+linear/polynomial calibration curves, dictionary replacement, and time parsing.
+"""
+
+import numpy as np
+
+
+class EnumConverterMissingKey(RuntimeError):
+    """During conversion a value was encountered which did not have a
+    corresponding key in the replacement dictionary.
+    """
+
+
+class Converter:
+    """Base class for all converter objects.
+
+    This class is extended to create converters, and users may extend this
+    class to write their own custom converters.
+
+    To write a converter, one must create a subclass and override either the method
+    `convert_many(field_array)` or `convert_one(field_array)`. The
+    `convert_many(field_array)` method implements the conversion for an entire
+    sequence of decoded packet field values in a single call (this is sometimes
+    faster), while the `convert_one(field_array)` method implements the
+    conversion for a single packet field at a time (this is sometimes easier to
+    write).
+    """
+
+    def __init__(self):
+        raise NotImplementedError("This is a base class not meant to be instantiated directly")
+
+    def convert_many(self, field_array):
+        """Convert a sequence of decoded packet field values.
+
+        This default implementation loops over the elements and defers the
+        conversion to `self.convert_one(field_array[i])`.
+
+        Parameters
+        ----------
+        field_array : NumPy array
+            decoded packet field values, must have at least one dimension
+
+        Returns
+        -------
+        converted_field_array : NumPy array
+            converted form of the decoded packet field values
+        """
+        converted_field_array = []
+
+        for i in range(field_array.shape[0]):
+            converted = self.convert_one(field_array[i])
+            converted_field_array.append(converted)
+
+        # Let NumPy infer the type from the elements.
+        converted_field_array = np.array(converted_field_array)
+
+        return converted_field_array
+
+    def convert_one(self, field_value):
+        """Convert a singel decoded packet field value.
+
+        Parameters
+        ----------
+        field_value : object
+            a single decoded packet field value
+
+        Returns
+        -------
+        converted_field_value : object
+            converted form of the decoded packet field value
+        """
+        raise NotImplementedError("This method must be overridden by a subclass")
+
+
+class PolyConverter(Converter):
+    """Post-processing conversion which applies calibration using a series
+    of coefficients ordered from highest power to intercept.
+    """
+
+    def __init__(self, coeffs):
+        """Instantiate a PolyConverter object
+
+        Parameters
+        ----------
+        coeffs : list of float
+           Polynomial coefficients ordered from highest power to intercept.
+        """
+        self._coeffs = coeffs
+
+    def convert_many(self, field_array):
+        """Apply the polynomial conversion.
+
+        Parameters
+        ----------
+        field_array : NumPy array
+            decoded packet field values, must have at least one dimension
+
+        Returns
+        -------
+        converted : NumPy array
+            converted form of the decoded packet field values
+        """
+        converted = np.zeros(field_array.shape, dtype=np.float64)
+
+        for power, coeff in enumerate(reversed(self._coeffs)):
+            converted += coeff * field_array**power
+
+        return converted
+
+
+class LinearConverter(PolyConverter):
+    """Post-processing conversion which applies a linear (y=mx+b)
+    transformation.
+    """
+
+    def __init__(self, slope, intercept):
+        """Instantiate a LinearConverter"""
+        super().__init__([slope, intercept])
+
+
+class EnumConverter(Converter):
+    """Post-processing conversion for applying dictionary replacement of
+    integers to strings.
+
+    If during conversion a value is encountered which does not have a
+    corresponding key in the replacement dictionary, then a
+    `:py:class:`~ccsdspy.converters.EnumConverterMissingKey` exception
+    will be thrown.
+    """
+
+    def __init__(self, replace_dict):
+        """Initialize a EnumConverter.
+
+        Parameters
+        ----------
+        replace_dict : dict of int to string
+           Replacement dictionary mapping integer values to string values
+
+        Raises
+        ------
+        ValueError
+           Either one of the keys of the replacement dictionary is not an
+           integer, or one of the values is not a string.
+        """
+        self._replace_dict = replace_dict
+
+        for key, value in replace_dict.items():
+            if not isinstance(key, int):
+                raise ValueError(
+                    f"Found key in EnumConverter replacement dictionary that is "
+                    f"not an integer: {repr(key)}"
+                )
+            if not isinstance(value, str):
+                raise ValueError(
+                    f"Found value in EnumConverter replacement dictionary that is "
+                    f"not a string: {repr(kevalue)}"
+                )
+
+    def convert_many(self, field_array):
+        """Apply the enum replacement conversion.
+
+        Parameters
+        ----------
+        field_array : NumPy array
+            decoded packet field values, must have at least one dimension
+
+        Returns
+        -------
+        converted : NumPy array
+            converted form of the decoded packet field values
+        """
+        converted = np.zeros(field_array.shape, dtype=object)
+        converted_mask = np.zeros(field_array.shape, dtype=bool)
+
+        for key, value in self._replace_dict.items():
+            converted[field_array == key] = value
+            converted_mask[field_array == key] = True
+
+        if not converted_mask.all():
+            missing_keys = field_array[~converted_mask].tolist()
+
+            raise EnumConverterMissingKey(
+                f"The following were encountered which did not have "
+                f"corresponding keys in the replacment dictionary: "
+                f"{repr(missing_keys)}"
+            )
+
+        return converted

--- a/ccsdspy/packet_fields.py
+++ b/ccsdspy/packet_fields.py
@@ -9,11 +9,15 @@ __author__ = "Daniel da Silva <mail@danieldasilva.org>"
 
 import numpy as np
 
+from .converters import Converter
+
 
 class PacketField:
     """A field contained in a packet."""
 
-    def __init__(self, name, data_type, bit_length, bit_offset=None, byte_order="big"):
+    def __init__(
+        self, name, data_type, bit_length, bit_offset=None, byte_order="big", converter=None
+    ):
         """
         Parameters
         ----------
@@ -30,6 +34,10 @@ class PacketField:
             from its position inside the packet definition.
         byte_order : {'big', 'little'}, optional
             Byte order of the field. Defaults to big endian.
+        converter : instance of subclass of  `:py:class:~ccsdspy.converter`, optional
+           A converter object to apply post-processing conversions, such as
+           calibration curves, value replacement, or time conversion. Converter objects
+           can be found in`:py:mod:~ccsdspy.converters`.
 
         Raises
         ------
@@ -55,11 +63,15 @@ class PacketField:
         if byte_order not in valid_byte_orders:
             raise ValueError(f"byte_order must be one of {valid_byte_orders}")
 
+        if converter is not None and not isinstance(converter, Converter):
+            raise ValueError("converter must be an instance of a Converter subclass")
+
         self._name = name
         self._data_type = data_type
         self._bit_length = bit_length
         self._bit_offset = bit_offset
         self._byte_order = byte_order
+        self._converter = converter
 
         self._field_type = "element"
         self._array_shape = None
@@ -71,7 +83,7 @@ class PacketField:
         return (
             "PacketField(name={_name}, data_type={_data_type}, "
             "bit_length={_bit_length}, bit_offset={_bit_offset}, "
-            "byte_order={_byte_order})".format(**values)
+            "byte_order={_byte_order}, converter={_converter})".format(**values)
         )
 
     def __iter__(self):

--- a/ccsdspy/packet_types.py
+++ b/ccsdspy/packet_types.py
@@ -481,5 +481,34 @@ def _load(file, fields, decoder_name, include_primary_header=False):
         )
 
     field_arrays = _unexpand_field_arrays(field_arrays, expand_history)
+    field_arrays = _apply_converters(field_arrays, fields)
 
     return field_arrays
+
+
+def _apply_converters(field_arrays, fields):
+    """Apply post-processing converters in place to a dictionary of field
+    arrays.
+
+    Parameters
+    ----------
+    field_arrays : dict of string to NumPy arrays
+       The decoded packet field arrays without any post-processing applied
+    fields : list of `ccsdspy.PacketField`
+      Layout of packet fields contained in the definition.
+
+    Returns
+    -------
+    converted_field_arrays : dict of string to NumPy arrays
+       The converted decoded packet field arrays, as a dictionary with the same
+       key as the passed `field_arrays`.
+    """
+    converted = field_arrays.copy()
+
+    for field in fields:
+        if field._converter is not None:
+            # Apply the conversion
+            converter = field._converter
+            converted[field._name] = converter.convert_many(field_arrays[field._name])
+
+    return converted

--- a/ccsdspy/tests/test_converters.py
+++ b/ccsdspy/tests/test_converters.py
@@ -1,0 +1,157 @@
+"""Tests for the ccsdspy.converters module"""
+
+import os
+
+import numpy as np
+import pytest
+
+from .. import converters
+from .. import FixedLength, VariableLength, PacketField
+
+TEST_FILENAME = "ccsds_converters_test.bin"
+
+
+def test_converter_cannot_be_instantiated():
+    with pytest.raises(NotImplementedError):
+        converters.Converter()
+
+
+def test_custom_class_with_missing_convert_one():
+    class Test(converters.Converter):
+        def __init__(self):
+            pass
+
+    with pytest.raises(NotImplementedError):
+        Test().convert_many(np.arange(10))
+
+
+@pytest.mark.parametrize("do_2darray", [False, True])
+def test_poly_converter_direct_simple(do_2darray):
+    coeffs = [0.3, 0.08, 5.4]
+
+    if do_2darray:
+        field_array = np.arange(200, dtype=int).reshape(5, 40)
+    else:
+        field_array = np.arange(10, dtype=int)
+
+    x = field_array.astype(np.float64)
+    expected = coeffs[0] * x**2 + coeffs[1] * x + coeffs[2]
+    got = converters.PolyConverter(coeffs).convert_many(field_array)
+
+    assert np.allclose(got, expected)
+
+
+@pytest.mark.parametrize("do_2darray", [False, True])
+def test_linear_converter_direct_simple(do_2darray):
+    slope, intercept = 1.2, 0.4
+
+    if do_2darray:
+        field_array = np.arange(200, dtype=int).reshape(5, 40)
+    else:
+        field_array = np.arange(10, dtype=int)
+    field_array = np.arange(10, dtype=int)
+
+    x = field_array.astype(np.float64)
+    expected = slope * x + intercept
+    got = converters.LinearConverter(slope, intercept).convert_many(field_array)
+
+    assert np.allclose(got, expected)
+
+
+@pytest.mark.parametrize("do_2darray", [False, True])
+def test_enum_converter_direct_happy_path(do_2darray):
+    replace_dict = {0: "OFF", 1: "ON", 2: "STANDBY", 3: "EMERGENCY"}
+
+    field_array = np.array([0, 3, 1, 1, 3, 2])
+    expected = np.array(["OFF", "EMERGENCY", "ON", "ON", "EMERGENCY", "STANDBY"])
+
+    if do_2darray:
+        shape = (3, 2)
+        field_array = field_array.reshape(shape)
+        expected = expected.reshape(shape)
+
+    got = converters.EnumConverter(replace_dict).convert_many(field_array)
+
+    assert np.all(got == expected)
+
+
+@pytest.mark.parametrize("do_2darray", [False, True])
+def test_enum_converter_direct_missing_key(do_2darray):
+    replace_dict = {0: "OFF", 1: "ON", 2: "STANDBY", 3: "EMERGENCY"}
+
+    # 8 is the missing value
+    field_array = np.array([0, 4, 1, 1, 3, 2])
+    expected = np.array(["OFF", "EMERGENCY", "ON", "ON", "EMERGENCY", "STANDBY"])
+
+    if do_2darray:
+        shape = (3, 2)
+        field_array = field_array.reshape(shape)
+        expected = expected.reshape(shape)
+
+    with pytest.raises(converters.EnumConverterMissingKey):
+        got = converters.EnumConverter(replace_dict).convert_many(field_array)
+
+
+def _create_simple_ccsds_packet(n=1):
+    packet_version_number = int("000", 2)
+    packet_type = int("0", 2)
+    secondary_header_flag = int("0", 2)
+    apid = 10
+    sequence_flag = 1
+    packet_counter = 0
+    packet_data_length = 4
+
+    CCSDS_PRIMARY_HEADER_LENGTH = 3
+    total_packet_length = CCSDS_PRIMARY_HEADER_LENGTH + packet_data_length
+
+    packet = np.zeros(total_packet_length * n, dtype=">u2")
+
+    for i in range(n):
+        packet[0 + i * total_packet_length] = (
+            (packet_version_number << 13)
+            + (packet_type << 12)
+            + (secondary_header_flag << 11)
+            + apid
+        )
+        packet[1 + i * total_packet_length] = (sequence_flag << 14) + packet_counter + i
+        packet[2 + i * total_packet_length] = (
+            packet_data_length * 2 - 1
+        )  # packet length in octets minus 2
+
+        packet[3 + i * total_packet_length] = i % 3
+        packet[4 + i * total_packet_length] = i % 5
+        packet[6 + i * total_packet_length] = i % 10
+
+    packet.tofile(TEST_FILENAME)
+    return packet
+
+
+@pytest.mark.parametrize("cls", [FixedLength, VariableLength])
+def test_end_to_end(cls):
+    num_packets = 75
+    packet = _create_simple_ccsds_packet(num_packets)  # noqa: F841
+
+    coeffs = [0.52, 0.1]
+    slope, intercept = 5.2, 1.2
+
+    boo_conv = converters.EnumConverter({0: "NO", 1: "YES", 2: "MAYBE"})
+    foo_conv = converters.LinearConverter(slope, intercept)
+    blah_conv = converters.PolyConverter(coeffs)
+
+    pkt = cls(
+        [
+            PacketField(name="BOO", data_type="uint", bit_length=16, converter=boo_conv),
+            PacketField(name="FOO", data_type="uint", bit_length=16, converter=foo_conv),
+            PacketField(name="BLAH", data_type="uint", bit_length=32, converter=blah_conv),
+        ]
+    )
+
+    result = pkt.load(TEST_FILENAME)
+
+    assert np.all(result["BOO"] == np.array(["NO", "YES", "MAYBE"] * (num_packets // 3)))
+    assert np.all(result["FOO"] == (np.arange(num_packets, dtype=int) % 5) * slope + intercept)
+    assert np.allclose(
+        result["BLAH"], (np.arange(num_packets, dtype=int) % 10) * coeffs[0] + coeffs[1]
+    )
+
+    os.remove(TEST_FILENAME)

--- a/ccsdspy/tests/test_primary_header.py
+++ b/ccsdspy/tests/test_primary_header.py
@@ -5,7 +5,7 @@ import pytest
 
 from .. import FixedLength, VariableLength, PacketField
 
-TEST_FILENAME = "ccsds_test.bin"
+TEST_FILENAME = "ccsds_primary_headers_test.bin"
 
 
 def create_simple_ccsds_packet(n=1):
@@ -32,7 +32,7 @@ def create_simple_ccsds_packet(n=1):
         packet[1 + i * total_packet_length] = (sequence_flag << 14) + packet_counter + i
         packet[2 + i * total_packet_length] = (
             packet_data_length * 2 - 1
-        )  # packet lenght in octets minus 2
+        )  # packet length in octets minus 2
 
         packet[3 + i * total_packet_length] = 314
         packet[4 + i * total_packet_length] = 512
@@ -57,7 +57,7 @@ def test_primary_header_contents_no_offset(cls):
         ]
     )
 
-    result = pkt.load("ccsds_test.bin", include_primary_header=True)
+    result = pkt.load(TEST_FILENAME, include_primary_header=True)
     assert (result["CCSDS_VERSION_NUMBER"] == np.zeros(num_packets, dtype="uint")).all()
     assert (result["CCSDS_PACKET_TYPE"] == np.zeros(num_packets, dtype="uint")).all()
     assert (result["CCSDS_SECONDARY_FLAG"] == np.zeros(num_packets, dtype="uint")).all()
@@ -85,7 +85,7 @@ def test_primary_header_contents_offset():
         ]
     )
 
-    result = pkt.load("ccsds_test.bin", include_primary_header=True)
+    result = pkt.load(TEST_FILENAME, include_primary_header=True)
     assert (result["CCSDS_VERSION_NUMBER"] == np.zeros(num_packets, dtype="uint")).all()
     assert (result["CCSDS_PACKET_TYPE"] == np.zeros(num_packets, dtype="uint")).all()
     assert (result["CCSDS_SECONDARY_FLAG"] == np.zeros(num_packets, dtype="uint")).all()


### PR DESCRIPTION
This change implements part of #51. It adds an API for "converters" to be added to packet fields, which apply post-processing transformations. The established use cases this post-processing are as follows:
1. Apply calibration curves to digital readout values
2. Convert Enum-like integers to human-readable strings
3. Convert binary representations of time to `datetime` instances

This change develops an API for converters, and implements 1 and 2 of the above. The API is roughly as follows. In addition to using the pre-made converters (currently `PolyConverter`, `LinearConverter`, and `EnumConverter`), users can subclass `ccsdspy.converters.Converter` and implement a method that applies their desired transformation.

```python
     from ccsdspy import FixedLength, PacketField
     from ccsdspy.converters import LinearConverter, PolyConverter

     pkt = FixedLength([
         ....
         PacketField(
              name="temperature", bit_length=8, data_type='uint',
              converter=LinearConverter(slope=1.2, intercept=-30)
         ),
         PacketField(
              name="current", bit_length=8, data_type='uint',
              converter=PolyConverter(coeffs=[0.1, 1.2, 0.3])
         ),
         ....
     ])

    result = pkt.load('MyCCSDS.bin')   # has conversions applied
```

