### PR TITLE
remove extra parenthesis

### DIFF
--- a/docs/user-guide/utils.rst
+++ b/docs/user-guide/utils.rst
@@ -73,7 +73,7 @@ The API method:
 
   from ccsdspy.utils import split_by_apid
 
-  with open('mixed_file.tlm', 'rb') as mixed_file):
+  with open('mixed_file.tlm', 'rb') as mixed_file:
       # dictionary mapping integer apid to BytesIO
       stream_by_apid = split_by_apid(mixed_file)
 


### PR DESCRIPTION
I noticed in the utils doc page that for the `split_by_apid` example there was an extra parenthesis in the code example. So I removed it.